### PR TITLE
Fixed the error 'createGainNode is not a function'

### DIFF
--- a/js/Runtime.js
+++ b/js/Runtime.js
@@ -42,7 +42,11 @@ Runtime.prototype.init = function() {
     this.scene = $('#container');
     window.AudioContext = window.AudioContext || window.webkitAudioContext;
     this.audioContext = new AudioContext();
-    this.audioGain = this.audioContext.createGainNode();
+		try{
+	    this.audioGain = this.audioContext.createGain();
+		}catch(err){
+			this.audioGain = this.audioContext.createGainNode();
+		}
     this.audioGain.connect(runtime.audioContext.destination);
 };
 


### PR DESCRIPTION
createGainNode has been replaced with createGain.

New versions of Firefox don't work with createGainNode. The fix works with new and old versions of browsers.
