### PR TITLE
Add crossOrigin attribute to imgs to prevent canvas tainted errors

### DIFF
--- a/js/Sprite.js
+++ b/js/Sprite.js
@@ -141,7 +141,7 @@ Sprite.prototype.attach = function(scene) {
             scene.append($(sprite.textures[c]));
         })
         .attr({
-            'crossOrigin': 'annonymous',
+            'crossOrigin': 'anonymous',
             'src': io.asset_base + this.costumes[c].baseLayerMD5 + io.asset_suffix
         });
     }


### PR DESCRIPTION
When attempting to load the index.html without using the proxy, I received the following errors -

```
Uncaught SecurityError: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The canvas has been tainted by cross-origin data. 
```

Adding the `crossOrigin` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin) with the value `annonymous` fixed the problem.
