### PR TITLE
Fix for canvas overlap multiplication

### DIFF
--- a/js/Sprite.js
+++ b/js/Sprite.js
@@ -255,6 +255,7 @@ Sprite.prototype.onClick = function(evt) {
 
         var idata = ctx.getImageData(mouseX, mouseY, 1, 1).data;
         var alpha = idata[3];
+        document.body.removeChild(canv);
     } else {
         var alpha = 1;
     }


### PR DESCRIPTION
This might be unnecessary, or fixed upstream in some other way, but it fixes the issue of canvases multiplying onclick in my current setup
