### PR TITLE
Add procedure support

### DIFF
--- a/js/Interpreter.js
+++ b/js/Interpreter.js
@@ -80,7 +80,7 @@ Interpreter.prototype.fixArgs = function(b) {
     var newArgs = [];
     for (var i = 0; i < b.args.length; i++) {
         var arg = b.args[i];
-        if (arg && arg.constructor == Array) {
+        if (b.op !== 'procDef' && arg && arg.constructor == Array) {
             if ((arg.length > 0) && (arg[0].constructor == Array)) {
                 // if first element arg is itself an array, then arg is a substack
                 if (!b.substack) {
@@ -93,7 +93,7 @@ Interpreter.prototype.fixArgs = function(b) {
                 newArgs.push(new Block(arg));
             }
         } else {
-            newArgs.push(arg); // arg is a constant
+            newArgs.push(arg); // arg is a constant or procDef arguments
         }
     }
     b.args = newArgs;
@@ -417,10 +417,10 @@ Interpreter.prototype.startSubstack = function(b, isLoop, secondSubstack) {
 
 Interpreter.prototype.primProcDef = function (b) {
     // proc name is arg 0
-    // fake block with param names is arg 1 ('op' is first block, 'args' is the rest)
-    // fake block default values for params is arg 2
+    // array with param names is arg 1
+    // array with default values for params is arg 2
     // and async flag is arg 3
-    b.procParams = [b.args[1].op].concat(b.args[1].args);
+    b.procParams = b.args[1];
     b.asyncFlag = b.args[3];
     // console.log('set param names for', b.args[0], ':', b.procParams);
 };

--- a/js/Runtime.js
+++ b/js/Runtime.js
@@ -70,6 +70,13 @@ Runtime.prototype.loadStart = function() {
         setTimeout(function(runtime) { runtime.loadStart(); }, 50, this);
         return;
     }
+    runtime.allStacksDo(function (stack, target) {
+        if (stack.op === 'procDef') {
+            target.procedures[stack.args[0]] = stack;
+            stack.primFcn(stack); // initialize parameters
+        }
+    });
+
     $('#preloader').css('display', 'none');
     setInterval(this.step, 33);
     this.projectLoaded = true;

--- a/js/Sprite.js
+++ b/js/Sprite.js
@@ -111,6 +111,9 @@ var Sprite = function(data) {
 
     // Stacks to be pushed to the interpreter and run
     this.stacks = [];
+
+    // Procedures by name
+    this.procedures = {};
 };
 
 // Attaches a Sprite (<img>) to a Scratch scene

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -51,7 +51,7 @@ Stage.prototype.attachPenLayer = function(scene) {
 };
 
 Stage.prototype.isLoaded = function() {
-    return this.penLayerLoaded && this.costumesLoaded == this.costumes.length && this.soundsLoaded == Object.keys(this.sounds).length;
+    return this.penLayerLoaded && Sprite.prototype.isLoaded.call(this);
 };
 
 // Pen functions

--- a/js/primitives/Primitives.js
+++ b/js/primitives/Primitives.js
@@ -105,4 +105,3 @@ Primitives.prototype.primMathFunction = function(b) {
     }
     return 0;
 }
-


### PR DESCRIPTION
- when a call block is executed, the block is copied, any parameters are
   evaluated and stored on the copy, then the copy is pushed on the stack
- when a getParam block is executed it finds the last call block on the
  stack, and then gets the already evaluated parameters from there.
- based on PR #21 by @bobbybee, passes all of @nathan's tests there