### PR TITLE
disabled scroll on keypress

### DIFF
--- a/js/Scratch.js
+++ b/js/Scratch.js
@@ -30,6 +30,9 @@ function Scratch(project_id) {
     $(window).keydown(function(e) {
         runtime.keysDown[e.which] = true;
         runtime.startKeyHats(e.which);
+        if (e.target==document.body) {
+            e.preventDefault();
+        }
     });
 
     $(window).keyup(function(e) {


### PR DESCRIPTION
Usually when pressing the spacebar or arrow keys and the screen is too small, the entire screen scrolls, which is distracting to the scratch project itself. This code fixes that bug.