### PR TITLE
Images URI formatting function and stopScripts block type.

### DIFF
--- a/js/Interpreter.js
+++ b/js/Interpreter.js
@@ -306,6 +306,9 @@ Interpreter.prototype.initPrims = function() {
     this.primitiveTable['timerReset'] = function(b) { interp.timerBase = Date.now(); };
     this.primitiveTable['timer'] = function(b) { return (Date.now() - interp.timerBase) / 1000; };
 
+	// added by Lucas
+	this.primitiveTable['stopScripts'] = function(b) { interp.activeThread = new Thread(null); interp.threads = []; };
+	
     new Primitives().addPrimsTo(this.primitiveTable);
 };
 

--- a/js/Sprite.js
+++ b/js/Sprite.js
@@ -113,6 +113,11 @@ var Sprite = function(data) {
     this.stacks = [];
 };
 
+// Creates a formatted URI for a costume image resource.
+Sprite.prototype.formatCostumeImageUri = function(costume, io) {
+	return io.asset_base + costume.baseLayerMD5 + io.asset_suffix;
+};
+
 // Attaches a Sprite (<img>) to a Scratch scene
 Sprite.prototype.attach = function(scene) {
     // Create textures and materials for each of the costumes.
@@ -142,7 +147,7 @@ Sprite.prototype.attach = function(scene) {
         })
         .attr({
             'crossOrigin': 'anonymous',
-            'src': io.asset_base + this.costumes[c].baseLayerMD5 + io.asset_suffix
+			'src': this.formatCostumeImageUri(this.costumes[c], io)
         });
     }
 


### PR DESCRIPTION
I moved function formatting URI for sprites' costumes, so it's easier to alter its behavior in case browser cannot handle the images correctly (in Firefox 40.0.2 there seems to be an issue with SVG images returned with "*application/octet-stream*" response content type assigned).

I've also added simple implementation of `'stopScripts'` command block.